### PR TITLE
mpi4py 2.0.0 version for python 2.7.12 and intel 2016b

### DIFF
--- a/easybuild/easyconfigs/m/mpi4py/mpi4py-2.0.0-intel-2016b-Python-2.7.12.eb
+++ b/easybuild/easyconfigs/m/mpi4py/mpi4py-2.0.0-intel-2016b-Python-2.7.12.eb
@@ -1,0 +1,26 @@
+easyblock = 'PythonPackage'
+
+name = 'mpi4py'
+version = '2.0.0'
+
+homepage = 'https://bitbucket.org/mpi4py/mpi4py'
+description = """MPI for Python (mpi4py) provides bindings of the Message Passing Interface (MPI) standard for
+ the Python programming language, allowing any Python program to exploit multiple processors."""
+
+toolchain = {'name': 'intel', 'version': '2016b'}
+
+source_urls = [BITBUCKET_DOWNLOADS]
+sources = [SOURCE_TAR_GZ]
+
+py_maj_min = '2.7'
+pyver = '%s.12' % py_maj_min
+versionsuffix = '-Python-%s' % pyver
+
+dependencies = [('Python', pyver)]
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/python%s/site-packages/mpi4py' % py_maj_min],
+}
+
+moduleclass = 'mpi'


### PR DESCRIPTION
First attempt of an mpi4py 2.0.0 in python 2.7.12 and intel 2016b
